### PR TITLE
Make internal formatters public for unit tests

### DIFF
--- a/TimeFormatters/DeltaSplitTimeFormatter.cs
+++ b/TimeFormatters/DeltaSplitTimeFormatter.cs
@@ -2,12 +2,12 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class DeltaSplitTimeFormatter : ITimeFormatter
+    public class DeltaSubsplitTimeFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
         public bool DropDecimals { get; set; }
 
-        public DeltaSplitTimeFormatter(TimeAccuracy accuracy, bool dropDecimals)
+        public DeltaSubsplitTimeFormatter(TimeAccuracy accuracy, bool dropDecimals)
         {
             Accuracy = accuracy;
             DropDecimals = dropDecimals;

--- a/TimeFormatters/RegularSplitTimeFormatter.cs
+++ b/TimeFormatters/RegularSplitTimeFormatter.cs
@@ -2,11 +2,11 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class RegularSplitTimeFormatter : ITimeFormatter
+    public class RegularSubsplitTimeFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
 
-        public RegularSplitTimeFormatter(TimeAccuracy accuracy)
+        public RegularSubsplitTimeFormatter(TimeAccuracy accuracy)
         {
             Accuracy = accuracy;
         }

--- a/UI/Components/LabelsComponent.cs
+++ b/UI/Components/LabelsComponent.cs
@@ -50,8 +50,8 @@ namespace LiveSplit.UI.Components
 
             MeasureTimeLabel = new SimpleLabel();
             MeasureDeltaLabel = new SimpleLabel();
-            TimeFormatter = new RegularSplitTimeFormatter(Settings.SplitTimesAccuracy);
-            DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+            TimeFormatter = new RegularSubsplitTimeFormatter(Settings.SplitTimesAccuracy);
+            DeltaTimeFormatter = new DeltaSubsplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
 
             Cache = new GraphicsCache();
             LabelsList = new List<SimpleLabel>();
@@ -78,12 +78,12 @@ namespace LiveSplit.UI.Components
 
             if (Settings.SplitTimesAccuracy != CurrentAccuracy)
             {
-                TimeFormatter = new RegularSplitTimeFormatter(Settings.SplitTimesAccuracy);
+                TimeFormatter = new RegularSubsplitTimeFormatter(Settings.SplitTimesAccuracy);
                 CurrentAccuracy = Settings.SplitTimesAccuracy;
             }
             if (Settings.DeltasAccuracy != CurrentDeltaAccuracy || Settings.DropDecimals != CurrentDropDecimals)
             {
-                DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+                DeltaTimeFormatter = new DeltaSubsplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
                 CurrentDeltaAccuracy = Settings.DeltasAccuracy;
                 CurrentDropDecimals = Settings.DropDecimals;
             }

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -103,10 +103,10 @@ namespace LiveSplit.UI.Components
             MeasureDeltaLabel = new SimpleLabel();
             Settings = settings;
             ColumnsList = columnsList;
-            TimeFormatter = new RegularSplitTimeFormatter(Settings.SplitTimesAccuracy);
-            DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
-            HeaderTimesFormatter = new RegularSplitTimeFormatter(Settings.HeaderAccuracy);
-            SectionTimerFormatter = new RegularSplitTimeFormatter(Settings.SectionTimerAccuracy);
+            TimeFormatter = new RegularSubsplitTimeFormatter(Settings.SplitTimesAccuracy);
+            DeltaTimeFormatter = new DeltaSubsplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+            HeaderTimesFormatter = new RegularSubsplitTimeFormatter(Settings.HeaderAccuracy);
+            SectionTimerFormatter = new RegularSubsplitTimeFormatter(Settings.SectionTimerAccuracy);
             MinimumHeight = 25;
             VerticalHeight = 31;
 
@@ -166,23 +166,23 @@ namespace LiveSplit.UI.Components
 
             if (Settings.SplitTimesAccuracy != CurrentAccuracy)
             {
-                TimeFormatter = new RegularSplitTimeFormatter(Settings.SplitTimesAccuracy);
+                TimeFormatter = new RegularSubsplitTimeFormatter(Settings.SplitTimesAccuracy);
                 CurrentAccuracy = Settings.SplitTimesAccuracy;
             }
             if (Settings.DeltasAccuracy != CurrentDeltaAccuracy || Settings.DropDecimals != CurrentDropDecimals)
             {
-                DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+                DeltaTimeFormatter = new DeltaSubsplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
                 CurrentDeltaAccuracy = Settings.DeltasAccuracy;
                 CurrentDropDecimals = Settings.DropDecimals;
             }
             if (Settings.HeaderAccuracy != CurrentHeaderTimesAccuracy)
             {
-                HeaderTimesFormatter = new RegularSplitTimeFormatter(Settings.HeaderAccuracy);
+                HeaderTimesFormatter = new RegularSubsplitTimeFormatter(Settings.HeaderAccuracy);
                 CurrentHeaderTimesAccuracy = Settings.HeaderAccuracy;
             }
             if (Settings.SectionTimerAccuracy != CurrentSectionTimerAccuracy)
             {
-                SectionTimerFormatter = new RegularSplitTimeFormatter(Settings.SectionTimerAccuracy);
+                SectionTimerFormatter = new RegularSubsplitTimeFormatter(Settings.SectionTimerAccuracy);
                 CurrentSectionTimerAccuracy = Settings.SectionTimerAccuracy;
             }
 
@@ -370,23 +370,23 @@ namespace LiveSplit.UI.Components
 
             if (Settings.SplitTimesAccuracy != CurrentAccuracy)
             {
-                TimeFormatter = new RegularSplitTimeFormatter(Settings.SplitTimesAccuracy);
+                TimeFormatter = new RegularSubsplitTimeFormatter(Settings.SplitTimesAccuracy);
                 CurrentAccuracy = Settings.SplitTimesAccuracy;
             }
             if (Settings.DeltasAccuracy != CurrentDeltaAccuracy || Settings.DropDecimals != CurrentDropDecimals)
             {
-                DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+                DeltaTimeFormatter = new DeltaSubsplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
                 CurrentDeltaAccuracy = Settings.DeltasAccuracy;
                 CurrentDropDecimals = Settings.DropDecimals;
             }
             if (Settings.HeaderAccuracy != CurrentHeaderTimesAccuracy)
             {
-                HeaderTimesFormatter = new RegularSplitTimeFormatter(Settings.HeaderAccuracy);
+                HeaderTimesFormatter = new RegularSubsplitTimeFormatter(Settings.HeaderAccuracy);
                 CurrentHeaderTimesAccuracy = Settings.HeaderAccuracy;
             }
             if (Settings.SectionTimerAccuracy != CurrentSectionTimerAccuracy)
             {
-                SectionTimerFormatter = new RegularSplitTimeFormatter(Settings.SectionTimerAccuracy);
+                SectionTimerFormatter = new RegularSubsplitTimeFormatter(Settings.SectionTimerAccuracy);
                 CurrentSectionTimerAccuracy = Settings.SectionTimerAccuracy;
             }
             


### PR DESCRIPTION
Allow unit tests to be created for all TimeFormatters. See: LiveSplit/LiveSplit#1446

Also change names to avoid conflict with LiveSplit.Splits