### PR TITLE
Completed and reference splits

### DIFF
--- a/UI/ColumnType.cs
+++ b/UI/ColumnType.cs
@@ -2,6 +2,6 @@
 {
     public enum ColumnType
     {
-        Delta, SplitTime, CompletedSplits, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
+        Delta, SplitTime, CompletedSplits, ReferenceSplits, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
     }
 }

--- a/UI/ColumnType.cs
+++ b/UI/ColumnType.cs
@@ -2,6 +2,6 @@
 {
     public enum ColumnType
     {
-        Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
+        Delta, SplitTime, CompletedSplits, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
     }
 }

--- a/UI/Components/ColumnSettings.Designer.cs
+++ b/UI/Components/ColumnSettings.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace LiveSplit.UI.Components
+﻿using System.Linq;
+
+namespace LiveSplit.UI.Components
 {
     partial class ColumnSettings
     {
@@ -127,17 +129,12 @@
             // 
             // cmbColumnType
             // 
+            System.Collections.IEnumerable colNames = from ColumnType type in System.Enum.GetValues(typeof(ColumnType)) select ColumnSettings.GetColumnType(type);
             this.cmbColumnType.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.cmbColumnType, 3);
             this.cmbColumnType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbColumnType.FormattingEnabled = true;
-            this.cmbColumnType.Items.AddRange(new object[] {
-            "Delta",
-            "Split Time",
-            "Delta or Split Time",
-            "Segment Delta",
-            "Segment Time",
-            "Segment Delta or Segment Time"});
+            this.cmbColumnType.Items.AddRange(colNames.Cast<object>().ToArray());
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/UI/Components/ColumnSettings.Designer.cs
+++ b/UI/Components/ColumnSettings.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace LiveSplit.UI.Components
+﻿namespace LiveSplit.UI.Components
 {
     partial class ColumnSettings
     {
@@ -129,12 +127,10 @@ namespace LiveSplit.UI.Components
             // 
             // cmbColumnType
             // 
-            System.Collections.IEnumerable colNames = from ColumnType type in System.Enum.GetValues(typeof(ColumnType)) select ColumnSettings.GetColumnType(type);
             this.cmbColumnType.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.cmbColumnType, 3);
             this.cmbColumnType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbColumnType.FormattingEnabled = true;
-            this.cmbColumnType.Items.AddRange(colNames.Cast<object>().ToArray());
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/UI/Components/ColumnSettings.cs
+++ b/UI/Components/ColumnSettings.cs
@@ -106,6 +106,8 @@ namespace LiveSplit.UI.Components
         {
             if (type == ColumnType.SplitTime)
                 return "Split Time";
+            else if (type == ColumnType.CompletedSplits)
+                return "Completed Splits";
             else if (type == ColumnType.Delta)
                 return "Delta";
             else if (type == ColumnType.DeltaorSplitTime)

--- a/UI/Components/ColumnSettings.cs
+++ b/UI/Components/ColumnSettings.cs
@@ -37,6 +37,10 @@ namespace LiveSplit.UI.Components
         {
             InitializeComponent();
 
+            System.Collections.IEnumerable colNames =
+                from ColumnType type in System.Enum.GetValues(typeof(ColumnType)) select GetColumnType(type);
+            this.cmbColumnType.Items.AddRange(colNames.Cast<object>().ToArray());
+
             Data = new ColumnData(columnName, ColumnType.Delta, "Current Comparison", "Current Timing Method");
 
             CurrentState = state;
@@ -108,6 +112,8 @@ namespace LiveSplit.UI.Components
                 return "Split Time";
             else if (type == ColumnType.CompletedSplits)
                 return "Completed Splits";
+            else if (type == ColumnType.ReferenceSplits)
+                return "Reference Splits";
             else if (type == ColumnType.Delta)
                 return "Delta";
             else if (type == ColumnType.DeltaorSplitTime)

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -755,6 +755,13 @@ namespace LiveSplit.UI.Components
 
             var type = data.Type;
 
+            if (type == ColumnType.ReferenceSplits)
+            {
+                label.ForeColor = state.LayoutSettings.TextColor;
+                label.Text = TimeFormatter.Format(Split.Comparisons[comparison][timingMethod]);
+                return;
+            }
+
             var splitIndex = state.Run.IndexOf(Split);
             if (splitIndex < state.CurrentSplitIndex)
             {

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -758,11 +758,12 @@ namespace LiveSplit.UI.Components
             var splitIndex = state.Run.IndexOf(Split);
             if (splitIndex < state.CurrentSplitIndex)
             {
-                if (type == ColumnType.SplitTime || type == ColumnType.SegmentTime)
+                // Formatting for each completed segment.
+                if (type == ColumnType.SplitTime || type == ColumnType.CompletedSplits || type == ColumnType.SegmentTime)
                 {
                     label.ForeColor = Settings.OverrideTimesColor ? Settings.BeforeTimesColor : state.LayoutSettings.TextColor;
 
-                    if (type == ColumnType.SplitTime)
+                    if (type == ColumnType.SplitTime || type == ColumnType.CompletedSplits)
                     {
                         label.Text = TimeFormatter.Format(Split.SplitTime[timingMethod]);
                     }
@@ -816,6 +817,7 @@ namespace LiveSplit.UI.Components
             }
             else
             {
+                // Formatting for each active or upcoming segment.
                 if (type == ColumnType.SplitTime || type == ColumnType.SegmentTime || type == ColumnType.DeltaorSplitTime || type == ColumnType.SegmentDeltaorSegmentTime)
                 {
                     if (IsActive)
@@ -852,7 +854,7 @@ namespace LiveSplit.UI.Components
                     label.Text = DeltaTimeFormatter.Format(bestDelta);
                     label.ForeColor = Settings.OverrideDeltasColor ? Settings.DeltasColor : state.LayoutSettings.TextColor;
                 }
-                else if (type == ColumnType.Delta || type == ColumnType.SegmentDelta)
+                else if (type == ColumnType.Delta || type == ColumnType.SegmentDelta || type == ColumnType.CompletedSplits)
                 {
                     label.Text = "";
                 }


### PR DESCRIPTION
This PR adds two new ColumnType options.  Both are intended to address [Issue 1424](https://github.com/LiveSplit/LiveSplit/issues/1424).

The first is "completed splits", which shows the time of completed splits but is otherwise blank.

The second is "reference splits", which always shows the reference time (e.g., personal best, etc.).

[This screenshot](https://i.imgur.com/tpPoxuq.jpg) shows example usage with three columns, of type "Reference Splits", "Delta", and "Completed Splits".

I've also added a few lines in the ColumnSettings constructor, which makes it easier to keep the ColumnType options in sync with displayed values.