### PR TITLE
ColumnType: CustomVariable

### DIFF
--- a/src/LiveSplit.Subsplits/UI/ColumnType.cs
+++ b/src/LiveSplit.Subsplits/UI/ColumnType.cs
@@ -2,5 +2,5 @@
 
 public enum ColumnType
 {
-    Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
+    Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime, CustomVariable
 }

--- a/src/LiveSplit.Subsplits/UI/Components/ColumnSettings.Designer.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/ColumnSettings.Designer.cs
@@ -137,7 +137,8 @@
             "Delta or Split Time",
             "Segment Delta",
             "Segment Time",
-            "Segment Delta or Segment Time"});
+            "Segment Delta or Segment Time",
+            "Custom Variable"});
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/src/LiveSplit.Subsplits/UI/Components/ColumnSettings.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/ColumnSettings.cs
@@ -131,9 +131,17 @@ public partial class ColumnSettings : UserControl
         {
             return "Segment Delta";
         }
-        else
+        else if (type == ColumnType.SegmentDeltaorSegmentTime)
         {
             return "Segment Delta or Segment Time";
+        }
+        else if (type == ColumnType.CustomVariable)
+        {
+            return "Custom Variable";
+        }
+        else
+        {
+            return "Unknown";
         }
     }
 

--- a/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
@@ -118,9 +118,13 @@ public class LabelsComponent : IComponent
                 {
                     labelWidth = MeasureDeltaLabel.ActualWidth;
                 }
-                else
+                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
                 {
                     labelWidth = MeasureTimeLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.CustomVariable)
+                {
+                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
                 }
 
                 curX -= labelWidth + 5;

--- a/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
@@ -5,24 +5,12 @@ using System.Linq;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
-using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
 public class LabelsComponent : IComponent
 {
     public SplitsSettings Settings { get; set; }
-
-    protected SimpleLabel MeasureTimeLabel { get; set; }
-    protected SimpleLabel MeasureDeltaLabel { get; set; }
-    protected SimpleLabel MeasureCharLabel { get; set; }
-
-    protected ITimeFormatter TimeFormatter { get; set; }
-    protected ITimeFormatter DeltaTimeFormatter { get; set; }
-
-    protected TimeAccuracy CurrentAccuracy { get; set; }
-    protected TimeAccuracy CurrentDeltaAccuracy { get; set; }
-    protected bool CurrentDropDecimals { get; set; }
 
     protected int FrameCount { get; set; }
 
@@ -51,12 +39,6 @@ public class LabelsComponent : IComponent
         Settings = settings;
         MinimumHeight = 31;
 
-        MeasureTimeLabel = new SimpleLabel();
-        MeasureDeltaLabel = new SimpleLabel();
-        MeasureCharLabel = new SimpleLabel();
-        TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
-        DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
-
         Cache = new GraphicsCache();
         LabelsList = [];
         ColumnsList = columns;
@@ -70,34 +52,6 @@ public class LabelsComponent : IComponent
             g.FillRectangle(new SolidBrush(
                 Settings.BackgroundColor
                 ), 0, 0, width, height);
-        }
-
-        MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
-        MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
-        MeasureCharLabel.Text = "W";
-
-        MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureTimeLabel.IsMonospaced = true;
-        MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureDeltaLabel.IsMonospaced = true;
-        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureCharLabel.IsMonospaced = true;
-
-        MeasureTimeLabel.SetActualWidth(g);
-        MeasureDeltaLabel.SetActualWidth(g);
-        MeasureCharLabel.SetActualWidth(g);
-
-        if (Settings.SplitTimesAccuracy != CurrentAccuracy)
-        {
-            TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
-            CurrentAccuracy = Settings.SplitTimesAccuracy;
-        }
-
-        if (Settings.DeltasAccuracy != CurrentDeltaAccuracy || Settings.DropDecimals != CurrentDropDecimals)
-        {
-            DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
-            CurrentDeltaAccuracy = Settings.DeltasAccuracy;
-            CurrentDropDecimals = Settings.DropDecimals;
         }
 
         foreach (SimpleLabel label in LabelsList)
@@ -120,29 +74,7 @@ public class LabelsComponent : IComponent
             float curX = width - 7;
             foreach (SimpleLabel label in LabelsList.Reverse())
             {
-                int i = LabelsList.IndexOf(label);
-                ColumnData column = ColumnsList.ElementAt(i);
-
-                float labelWidth = 0f;
-                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
-                {
-                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
-                }
-                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
-                {
-                    labelWidth = MeasureDeltaLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
-                {
-                    labelWidth = MeasureTimeLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.CustomVariable)
-                {
-                    labelWidth = MeasureCharLabel.ActualWidth;
-                }
-
-                labelWidth = Math.Max(ColumnWidths[i], labelWidth);
-                ColumnWidths[i] = labelWidth;
+                float labelWidth = ColumnWidths[LabelsList.IndexOf(label)];
 
                 curX -= labelWidth + 5;
                 label.Width = labelWidth;

--- a/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
@@ -15,6 +15,7 @@ public class LabelsComponent : IComponent
 
     protected SimpleLabel MeasureTimeLabel { get; set; }
     protected SimpleLabel MeasureDeltaLabel { get; set; }
+    protected SimpleLabel MeasureCharLabel { get; set; }
 
     protected ITimeFormatter TimeFormatter { get; set; }
     protected ITimeFormatter DeltaTimeFormatter { get; set; }
@@ -29,6 +30,7 @@ public class LabelsComponent : IComponent
 
     public IEnumerable<ColumnData> ColumnsList { get; set; }
     public IList<SimpleLabel> LabelsList { get; set; }
+    protected List<float> ColumnWidths { get; }
 
     public float PaddingTop => 0f;
     public float PaddingLeft => 0f;
@@ -44,19 +46,21 @@ public class LabelsComponent : IComponent
     public float MinimumHeight { get; set; }
 
     public IDictionary<string, Action> ContextMenuControls => null;
-    public LabelsComponent(SplitsSettings settings, IEnumerable<ColumnData> columns)
+    public LabelsComponent(SplitsSettings settings, IEnumerable<ColumnData> columns, List<float> columnWidths)
     {
         Settings = settings;
         MinimumHeight = 31;
 
         MeasureTimeLabel = new SimpleLabel();
         MeasureDeltaLabel = new SimpleLabel();
+        MeasureCharLabel = new SimpleLabel();
         TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
         DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
 
         Cache = new GraphicsCache();
         LabelsList = [];
         ColumnsList = columns;
+        ColumnWidths = columnWidths;
     }
 
     private void DrawGeneral(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode)
@@ -70,14 +74,18 @@ public class LabelsComponent : IComponent
 
         MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
         MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
+        MeasureCharLabel.Text = "W";
 
         MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
         MeasureTimeLabel.IsMonospaced = true;
         MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
         MeasureDeltaLabel.IsMonospaced = true;
+        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureCharLabel.IsMonospaced = true;
 
         MeasureTimeLabel.SetActualWidth(g);
         MeasureDeltaLabel.SetActualWidth(g);
+        MeasureCharLabel.SetActualWidth(g);
 
         if (Settings.SplitTimesAccuracy != CurrentAccuracy)
         {
@@ -104,10 +112,16 @@ public class LabelsComponent : IComponent
 
         if (ColumnsList.Count() == LabelsList.Count)
         {
+            while (ColumnWidths.Count < LabelsList.Count)
+            {
+                ColumnWidths.Add(0f);
+            }
+
             float curX = width - 7;
             foreach (SimpleLabel label in LabelsList.Reverse())
             {
-                ColumnData column = ColumnsList.ElementAt(LabelsList.IndexOf(label));
+                int i = LabelsList.IndexOf(label);
+                ColumnData column = ColumnsList.ElementAt(i);
 
                 float labelWidth = 0f;
                 if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
@@ -124,8 +138,11 @@ public class LabelsComponent : IComponent
                 }
                 else if (column.Type is ColumnType.CustomVariable)
                 {
-                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
+                    labelWidth = MeasureCharLabel.ActualWidth;
                 }
+
+                labelWidth = Math.Max(ColumnWidths[i], labelWidth);
+                ColumnWidths[i] = labelWidth;
 
                 curX -= labelWidth + 5;
                 label.Width = labelWidth;

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -935,10 +935,16 @@ public class SplitComponent : IComponent
                     label.Text = DeltaTimeFormatter.Format(segmentDelta);
                 }
             }
+
+            else if (type is ColumnType.CustomVariable)
+            {
+                Split.CustomVariableValues.TryGetValue(data.Name, out string text);
+                label.Text = text ?? "";
+            }
         }
         else
         {
-            if (type is ColumnType.SplitTime or ColumnType.SegmentTime or ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
+            if (type is ColumnType.SplitTime or ColumnType.SegmentTime or ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime or ColumnType.CustomVariable)
             {
                 if (IsActive)
                 {
@@ -953,7 +959,7 @@ public class SplitComponent : IComponent
                 {
                     label.Text = TimeFormatter.Format(Split.Comparisons[comparison][timingMethod]);
                 }
-                else //SegmentTime or SegmentTimeorSegmentDeltaTime
+                else if (type is ColumnType.SegmentTime or ColumnType.SegmentDeltaorSegmentTime)
                 {
                     TimeSpan previousTime = TimeSpan.Zero;
                     for (int index = splitIndex - 1; index >= 0; index--)
@@ -982,6 +988,17 @@ public class SplitComponent : IComponent
             else if (type is ColumnType.Delta or ColumnType.SegmentDelta)
             {
                 label.Text = "";
+            }
+            else if (type is ColumnType.CustomVariable)
+            {
+                if (Split == state.CurrentSplit)
+                {
+                    label.Text = state.Run.Metadata.CustomVariableValue(data.Name) ?? "";
+                }
+                else
+                {
+                    label.Text = "";
+                }
             }
         }
     }

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -1051,7 +1051,7 @@ public class SplitComponent : IComponent
         int splitIndex = state.Run.IndexOf(Split);
         if (splitIndex < state.CurrentSplitIndex)
         {
-            if (type is ColumnType.SplitTime or ColumnType.SegmentTime)
+            if (type is ColumnType.SplitTime or ColumnType.SegmentTime or ColumnType.CustomVariable)
             {
                 label.ForeColor = Settings.OverrideTimesColor ? Settings.BeforeTimesColor : state.LayoutSettings.TextColor;
 
@@ -1059,10 +1059,15 @@ public class SplitComponent : IComponent
                 {
                     label.Text = TimeFormatter.Format(Split.SplitTime[timingMethod]);
                 }
-                else //SegmentTime
+                else if (type == ColumnType.SegmentTime)
                 {
                     TimeSpan? segmentTime = getSectionTime(state, splitIndex, TopSplit, comparison, timingMethod);
                     label.Text = TimeFormatter.Format(segmentTime);
+                }
+                else if (type == ColumnType.CustomVariable)
+                {
+                    Split.CustomVariableValues.TryGetValue(data.Name, out string text);
+                    label.Text = text ?? "";
                 }
             }
 
@@ -1123,11 +1128,6 @@ public class SplitComponent : IComponent
                 {
                     label.Text = DeltaTimeFormatter.Format(segmentDelta);
                 }
-            }
-            else if (type is ColumnType.CustomVariable)
-            {
-                Split.CustomVariableValues.TryGetValue(data.Name, out string text);
-                label.Text = text ?? "";
             }
         }
         else

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -27,9 +27,6 @@ public class SplitComponent : IComponent
 
     protected SimpleLabel NameLabel { get; set; }
     protected SimpleLabel TimeLabel { get; set; }
-    protected SimpleLabel MeasureTimeLabel { get; set; }
-    protected SimpleLabel MeasureDeltaLabel { get; set; }
-    protected SimpleLabel MeasureCharLabel { get; set; }
     protected SimpleLabel HeaderMeasureTimeLabel { get; set; }
     protected SimpleLabel HeaderMeasureDeltaLabel { get; set; }
     protected SimpleLabel DeltaLabel { get; set; }
@@ -98,7 +95,6 @@ public class SplitComponent : IComponent
             Y = 3,
             Text = ""
         };
-        MeasureTimeLabel = new SimpleLabel();
         HeaderMeasureTimeLabel = new SimpleLabel();
         DeltaLabel = new SimpleLabel()
         {
@@ -106,9 +102,7 @@ public class SplitComponent : IComponent
             Y = 3,
             Text = ""
         };
-        MeasureDeltaLabel = new SimpleLabel();
         HeaderMeasureDeltaLabel = new SimpleLabel();
-        MeasureCharLabel = new SimpleLabel();
         Settings = settings;
         ColumnsList = columnsList;
         ColumnWidths = columnWidths;
@@ -128,26 +122,14 @@ public class SplitComponent : IComponent
 
     private void SetMeasureLabels(Graphics g, LiveSplitState state)
     {
-        MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
-        MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
-        MeasureCharLabel.Text = "W";
         HeaderMeasureTimeLabel.Text = HeaderTimesFormatter.Format(new TimeSpan(24, 0, 0));
         HeaderMeasureDeltaLabel.Text = SectionTimerFormatter.Format(new TimeSpan(0, 9, 0, 0));
 
-        MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureTimeLabel.IsMonospaced = true;
-        MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureDeltaLabel.IsMonospaced = true;
-        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureCharLabel.IsMonospaced = true;
         HeaderMeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
         HeaderMeasureTimeLabel.IsMonospaced = true;
         HeaderMeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
         HeaderMeasureDeltaLabel.IsMonospaced = true;
 
-        MeasureTimeLabel.SetActualWidth(g);
-        MeasureDeltaLabel.SetActualWidth(g);
-        MeasureCharLabel.SetActualWidth(g);
         HeaderMeasureTimeLabel.SetActualWidth(g);
         HeaderMeasureDeltaLabel.SetActualWidth(g);
     }
@@ -331,29 +313,7 @@ public class SplitComponent : IComponent
                 float nameX = width - 7;
                 foreach (SimpleLabel label in LabelsList.Reverse())
                 {
-                    int i = LabelsList.IndexOf(label);
-                    ColumnData column = ColumnsList.ElementAt(i);
-
-                    float labelWidth = 0f;
-                    if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
-                    {
-                        labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
-                    }
-                    else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
-                    {
-                        labelWidth = MeasureDeltaLabel.ActualWidth;
-                    }
-                    else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
-                    {
-                        labelWidth = MeasureTimeLabel.ActualWidth;
-                    }
-                    else if (column.Type is ColumnType.CustomVariable)
-                    {
-                        labelWidth = MeasureCharLabel.ActualWidth;
-                    }
-
-                    labelWidth = Math.Max(ColumnWidths[i], labelWidth);
-                    ColumnWidths[i] = labelWidth;
+                    float labelWidth = ColumnWidths[LabelsList.IndexOf(label)];
 
                     label.Width = labelWidth + 20;
                     curX -= labelWidth + 5;
@@ -367,7 +327,6 @@ public class SplitComponent : IComponent
                     if (!string.IsNullOrEmpty(label.Text))
                     {
                         nameX = curX + labelWidth + 5 - label.ActualWidth;
-                        ColumnWidths[i] = Math.Max(ColumnWidths[i], label.ActualWidth + 5);
                     }
                 }
 
@@ -1218,44 +1177,9 @@ public class SplitComponent : IComponent
 
     protected float CalculateLabelsWidth()
     {
-        if (ColumnsList != null)
+        if (ColumnWidths != null)
         {
-            while (ColumnWidths.Count < ColumnsList.Count())
-            {
-                ColumnWidths.Add(0f);
-            }
-
-            float totalWidth = 0f;
-
-            for (int i = 0; i < ColumnsList.Count(); i++)
-            {
-                ColumnData column = ColumnsList.ElementAt(i);
-
-                float labelWidth = 0f;
-                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
-                {
-                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
-                }
-                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
-                {
-                    labelWidth = MeasureDeltaLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
-                {
-                    labelWidth = MeasureTimeLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.CustomVariable)
-                {
-                    labelWidth = MeasureCharLabel.ActualWidth;
-                }
-
-                labelWidth = Math.Max(ColumnWidths[i], labelWidth);
-                ColumnWidths[i] = labelWidth;
-
-                totalWidth += labelWidth + 5;
-            }
-
-            return totalWidth;
+            return ColumnWidths.Sum() + (5 * ColumnWidths.Count());
         }
 
         return 0f;
@@ -1315,8 +1239,6 @@ public class SplitComponent : IComponent
                 Cache["Columns" + index + "Color"] = label.ForeColor.ToArgb();
             }
 
-            Cache["MeasureTimeActualWidth"] = MeasureTimeLabel.ActualWidth;
-            Cache["MeasureDeltaActualWidth"] = MeasureDeltaLabel.ActualWidth;
             Cache["HeaderMeasureTimeActualWidth"] = HeaderMeasureTimeLabel.ActualWidth;
             Cache["HeaderMeasureDeltaActualWidth"] = HeaderMeasureDeltaLabel.ActualWidth;
             Cache["Header"] = Header;

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -868,7 +868,7 @@ public class SplitComponent : IComponent
         int splitIndex = state.Run.IndexOf(Split);
         if (splitIndex < state.CurrentSplitIndex)
         {
-            if (type is ColumnType.SplitTime or ColumnType.SegmentTime)
+            if (type is ColumnType.SplitTime or ColumnType.SegmentTime or ColumnType.CustomVariable)
             {
                 label.ForeColor = Settings.OverrideTimesColor ? Settings.BeforeTimesColor : state.LayoutSettings.TextColor;
 
@@ -876,10 +876,15 @@ public class SplitComponent : IComponent
                 {
                     label.Text = TimeFormatter.Format(Split.SplitTime[timingMethod]);
                 }
-                else //SegmentTime
+                else if (type == ColumnType.SegmentTime)
                 {
                     TimeSpan? segmentTime = LiveSplitStateHelper.GetPreviousSegmentTime(state, splitIndex, timingMethod);
                     label.Text = TimeFormatter.Format(segmentTime);
+                }
+                else if (type == ColumnType.CustomVariable)
+                {
+                    Split.CustomVariableValues.TryGetValue(data.Name, out string text);
+                    label.Text = text ?? "";
                 }
             }
 
@@ -938,12 +943,6 @@ public class SplitComponent : IComponent
                 {
                     label.Text = DeltaTimeFormatter.Format(segmentDelta);
                 }
-            }
-
-            else if (type is ColumnType.CustomVariable)
-            {
-                Split.CustomVariableValues.TryGetValue(data.Name, out string text);
-                label.Text = text ?? "";
             }
         }
         else

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -1237,6 +1237,10 @@ public class SplitComponent : IComponent
                 SimpleLabel label = LabelsList[index];
                 Cache["Columns" + index + "Text"] = label.Text;
                 Cache["Columns" + index + "Color"] = label.ForeColor.ToArgb();
+                if (index < ColumnWidths.Count)
+                {
+                    Cache["Columns" + index + "Width"] = ColumnWidths[index];
+                }
             }
 
             Cache["HeaderMeasureTimeActualWidth"] = HeaderMeasureTimeLabel.ActualWidth;

--- a/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
@@ -408,6 +408,7 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
         SetMeasureLabels(g, state);
+        CalculateColumnWidths(state.Run);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -416,6 +417,7 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
         SetMeasureLabels(g, state);
+        CalculateColumnWidths(state.Run);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -683,8 +685,6 @@ public class SplitsComponent : IComponent
 
             i++;
         }
-
-        CalculateColumnWidths(state.Run);
 
         if (invalidator != null)
         {

--- a/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
@@ -408,7 +408,6 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
         SetMeasureLabels(g, state);
-        CalculateColumnWidths(state.Run);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -417,7 +416,6 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
         SetMeasureLabels(g, state);
-        CalculateColumnWidths(state.Run);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -685,6 +683,8 @@ public class SplitsComponent : IComponent
 
             i++;
         }
+
+        CalculateColumnWidths(state.Run);
 
         if (invalidator != null)
         {

--- a/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
@@ -22,6 +23,13 @@ public class SplitsComponent : IComponent
     protected IList<SplitComponent> SplitComponents { get; set; }
 
     protected SplitsSettings Settings { get; set; }
+
+    protected SimpleLabel MeasureTimeLabel { get; set; }
+    protected SimpleLabel MeasureDeltaLabel { get; set; }
+    protected SimpleLabel MeasureCharLabel { get; set; }
+
+    protected ITimeFormatter TimeFormatter { get; set; }
+    protected ITimeFormatter DeltaTimeFormatter { get; set; }
 
     private Dictionary<Image, Image> ShadowImages { get; set; }
 
@@ -62,6 +70,13 @@ public class SplitsComponent : IComponent
         CurrentState = state;
         Settings = new SplitsSettings(state);
         InternalComponent = new ComponentRendererComponent();
+
+        MeasureTimeLabel = new SimpleLabel();
+        MeasureDeltaLabel = new SimpleLabel();
+        MeasureCharLabel = new SimpleLabel();
+        TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
+        DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+
         ShadowImages = [];
         visualSplitCount = Settings.VisualSplitCount;
         Settings.SplitLayoutChanged += Settings_SplitLayoutChanged;
@@ -370,10 +385,29 @@ public class SplitsComponent : IComponent
         }
     }
 
+    private void SetMeasureLabels(Graphics g, LiveSplitState state)
+    {
+        MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
+        MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
+        MeasureCharLabel.Text = "W";
+
+        MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureTimeLabel.IsMonospaced = true;
+        MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureDeltaLabel.IsMonospaced = true;
+        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureCharLabel.IsMonospaced = true;
+
+        MeasureTimeLabel.SetActualWidth(g);
+        MeasureDeltaLabel.SetActualWidth(g);
+        MeasureCharLabel.SetActualWidth(g);
+    }
+
     public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
     {
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
+        SetMeasureLabels(g, state);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -381,6 +415,7 @@ public class SplitsComponent : IComponent
     {
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
+        SetMeasureLabels(g, state);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -649,9 +684,56 @@ public class SplitsComponent : IComponent
             i++;
         }
 
+        CalculateColumnWidths(state.Run);
+
         if (invalidator != null)
         {
             InternalComponent.Update(invalidator, state, width, height, mode);
+        }
+    }
+
+    private void CalculateColumnWidths(IRun run)
+    {
+        if (ColumnsList != null)
+        {
+            while (ColumnWidths.Count < ColumnsList.Count())
+            {
+                ColumnWidths.Add(0f);
+            }
+
+            for (int i = 0; i < ColumnsList.Count(); i++)
+            {
+                ColumnData column = ColumnsList.ElementAt(i);
+
+                float labelWidth = 0f;
+                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
+                {
+                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
+                }
+                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
+                {
+                    labelWidth = MeasureDeltaLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
+                {
+                    labelWidth = MeasureTimeLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.CustomVariable)
+                {
+                    int longest_length = run.Metadata.CustomVariableValue(column.Name).Length;
+                    foreach (ISegment split in run)
+                    {
+                        if (split.CustomVariableValues.TryGetValue(column.Name, out string value) && !string.IsNullOrEmpty(value))
+                        {
+                            longest_length = Math.Max(longest_length, value.Length);
+                        }
+                    }
+
+                    labelWidth = MeasureCharLabel.ActualWidth * longest_length;
+                }
+
+                ColumnWidths[i] = labelWidth;
+            }
         }
     }
 

--- a/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
@@ -42,6 +42,7 @@ public class SplitsComponent : IComponent
     protected Color OldShadowsColor { get; set; }
 
     protected IEnumerable<ColumnData> ColumnsList => Settings.ColumnsList.Select(x => x.Data);
+    protected List<float> ColumnWidths { get; set; }
 
     public string ComponentName
       => "Subsplits";
@@ -64,6 +65,7 @@ public class SplitsComponent : IComponent
         ShadowImages = [];
         visualSplitCount = Settings.VisualSplitCount;
         Settings.SplitLayoutChanged += Settings_SplitLayoutChanged;
+        ColumnWidths = Settings.ColumnsList.Select(_ => 0f).ToList();
         ScrollOffset = 0;
         RebuildVisualSplits();
         sectionList = new SectionList();
@@ -102,7 +104,7 @@ public class SplitsComponent : IComponent
 
         if (Settings.ShowColumnLabels && CurrentState.Layout?.Mode == LayoutMode.Vertical)
         {
-            Components.Add(new LabelsComponent(Settings, ColumnsList));
+            Components.Add(new LabelsComponent(Settings, ColumnsList, ColumnWidths));
             Components.Add(new SeparatorComponent());
         }
 
@@ -121,7 +123,7 @@ public class SplitsComponent : IComponent
                 }
             }
 
-            var splitComponent = new SplitComponent(Settings, ColumnsList);
+            var splitComponent = new SplitComponent(Settings, ColumnsList, ColumnWidths);
             Components.Add(splitComponent);
             SplitComponents.Add(splitComponent);
 


### PR DESCRIPTION
A companion PR to https://github.com/LiveSplit/LiveSplit/pull/2528, and the Subsplits version of https://github.com/LiveSplit/LiveSplit.Splits/pull/27. Allows a column in the splits component to display the value of a Custom Variable, with Column Type choice option.

Depends on https://github.com/LiveSplit/LiveSplit/pull/2600.

Tasks:
- [x] Test behavior on skipped splits. If different from LiveSplit One, fix it to match.
- [x] Test behavior when splits scroll up and down.
- [x] Make sure past segment custom variable values are preserved when switching layouts, and show as the normal text color, not black