### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/LabelsComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -10,6 +10,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TextFont)]
 public class LabelsComponent : IComponent
 {
     public SplitsSettings Settings { get; set; }

--- a/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -12,6 +12,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.All)]
 public class SplitComponent : IComponent
 {
     public bool Header { get; set; }

--- a/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Subsplits/UI/Components/SplitsComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -10,6 +10,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimesFont)]
 public class SplitsComponent : IComponent
 {
     public ComponentRendererComponent InternalComponent { get; protected set; }


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688